### PR TITLE
Downloading binary and avoid multistage build compilation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,17 @@ version: '3.3'
 
 services:
   node:
-    image: senseinode/polkadot:latest # You can use your own build
+    image: senseinode/polkadot:latest
     restart: unless-stopped
-    env_file: .env
     ports:
       - 9933:9933
       - 30333:30333
     volumes:
       - data:/data
       - backup:/root/.local/share/polkadot
+    environment:
+      - SNAP_MODE=false
+      - CHAIN=polkadot
 
 volumes:
   data:

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,9 +1,22 @@
+# syntax=docker/dockerfile:1
+
+# Builder phase
+FROM ubuntu:22.04 as builder
+
+RUN ["apt", "update"]
+RUN ["apt", "install", "-y", "wget"]
+
+CMD ["bash"]
+
+RUN wget https://github.com/paritytech/polkadot/releases/download/v0.9.25/polkadot
+
+# Running image 
 FROM ubuntu:22.04
 
 WORKDIR /data
 
-RUN ["wget", "https://github.com/paritytech/polkadot/releases/download/v0.9.25/polkadot"]
-RUN ["chmod", "+x", "./polkadot"]
+COPY --from=builder  /polkadot .
+RUN chmod +x ./polkadot
 
 ENV RUST_BACKTRACE=1
 ENV SNAP_MODE=false

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,37 +1,15 @@
-# syntax=docker/dockerfile:1
-
-# Builder phase
-FROM rust:latest as builder
-
-RUN ["rustup", "update"]
-RUN ["apt", "update"]
-RUN ["apt", "install", "-y", "make", "clang", "pkg-config", "libssl-dev", "build-essential", "ntp"]
-
-CMD ["bash"]
-
-RUN git clone https://github.com/paritytech/polkadot.git
-WORKDIR /polkadot
-
-RUN git checkout v0.9.16
-RUN ./scripts/init.sh
-RUN cargo build --release
-
-# Actual image 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 WORKDIR /data
 
-COPY --from=builder  /polkadot/target/release/polkadot .
-
-COPY ./init.sh .
+RUN ["wget", "https://github.com/paritytech/polkadot/releases/download/v0.9.25/polkadot"]
+RUN ["chmod", "+x", "./polkadot"]
 
 ENV RUST_BACKTRACE=1
-
 ENV SNAP_MODE=false
-
 ENV CHAIN=polkadot
 
+COPY ./init.sh .
 RUN chmod +x ./init.sh
 
 ENTRYPOINT [ "./init.sh" ]
-


### PR DESCRIPTION
# Description

With this change, the docker image won't be downloading client source code in order to compile it in a multistage build; instead will download the binary.

- Polkadot release version: [v0.9.25](https://github.com/paritytech/polkadot/releases/tag/v0.9.25)
- Senseinode image tag: [senseinode/polkadot:latest](https://hub.docker.com/layers/193224983/senseinode/polkadot/latest/images/sha256-c4fccd4917a7202a6483a73b67bae094e074c040090fe5bd19837db44ca78517?context=repo)